### PR TITLE
Workaround to make lib importable from Swift

### DIFF
--- a/Empty.m
+++ b/Empty.m
@@ -1,0 +1,3 @@
+#import "MPulse.h"
+@implementation MPulse (ForceLoad) 
+@end

--- a/mPulse.podspec
+++ b/mPulse.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios
   s.ios.deployment_target = "6.0"
 
-  s.source_files   = 'include/*.h'
+  s.source_files   = 'include/*.h', 'Empty.m'
   s.public_header_files = 'include/*.h'
   s.preserve_paths = 'libMPulse.a', 'libMPulseSim.a'
   s.ios.vendored_library = 'libMPulse.a', 'libMPulseSim.a'


### PR DESCRIPTION
With the presence of `Empty.m`, the cocoapod install will create a modulemap and other support files that make it importable from Swift.
