### PR TITLE
Rename libmPulse.a to libmPulseDevice.a

### DIFF
--- a/mPulse.podspec
+++ b/mPulse.podspec
@@ -15,9 +15,9 @@ Pod::Spec.new do |s|
 
   s.source_files   = 'include/*.h', 'Empty.m'
   s.public_header_files = 'include/*.h'
-  s.preserve_paths = 'libmPulse.a', 'libmPulseSim.a'
-  s.ios.vendored_library = 'libmPulse.a', 'libmPulseSim.a'
-  s.libraries      = 'z', 'c++', 'mPulse', 'mPulseSim'
+  s.preserve_paths = 'libmPulseDevice.a', 'libmPulseSim.a'
+  s.ios.vendored_library = 'libmPulseDevice.a', 'libmPulseSim.a'
+  s.libraries      = 'z', 'c++', 'mPulseDevice', 'mPulseSim'
   s.frameworks     = 'CoreLocation', 'CoreTelephony', 'SystemConfiguration'
   s.requires_arc   = true
 


### PR DESCRIPTION
To avoid library name clashes with the pod itself being a `libmPulse.a`.
