### PR TITLE
PodSpec: Remove mPulse from libraries

### DIFF
--- a/mPulse.podspec
+++ b/mPulse.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.public_header_files = 'include/*.h'
   s.preserve_paths = 'libmPulseDevice.a', 'libmPulseSim.a'
   s.ios.vendored_library = 'libmPulseDevice.a', 'libmPulseSim.a'
-  s.libraries      = 'z', 'c++', 'mPulseDevice', 'mPulseSim'
+  s.libraries      = 'z', 'c++'
   s.frameworks     = 'CoreLocation', 'CoreTelephony', 'SystemConfiguration'
   s.requires_arc   = true
 


### PR DESCRIPTION
This removes `'mPulseDevice', 'mPulseSim'` from the `s.libraries` section of the PodSpec.  [`libraries`](https://guides.cocoapods.org/syntax/podspec.html#libraries) is intended to only be used for external/system libraries that need to be linked to:

> libraries
> A list of system libraries that the user’s target (application) needs to link against.

The mPulse PodSpec has included the mPulse pod's own libraries in that list for a while:

```
s.libraries      = 'z', 'c++', 'mPulseDevice', 'mPulseSim'
```

Starting with CocoaPods 1.6+ (and still in 1.7+), having the mPulse libraries specified in `s.libraries` updates the `OTHER_LDFLAGS` in `Pods/Target Support Files/Pods-app/Pods-app.release.xcconfig` to include `-l"mPulseDevice" -l"mPulseSim"` even if `use_frameworks!` is specified in the `Podfile`.  This can lead to mPulse being included "twice" in a project (e.g. `mpulse.a` and `app.a`), which can lead to [crashes](https://github.com/akamai/mPulse-iOS/issues/10#issuecomment-493583698) and other problems.

Example `OTHER_LDFLAGS` in `Pods/Target Support Files/Pods-XYZ/Pods-XYZ.release.xcconfig` before this fix, when using CocoaPods 1.6+.  We incorrectly include `-l"mPulseDevice" -l"mPulseSim"` *and* `-framework "mPulse"`

```
OTHER_LDFLAGS = $(inherited) -ObjC -l"c++"
  -l"mPulseDevice" -l"mPulseSim"
  -l"sqlite3" -l"z"
  -framework "CoreData" -framework "CoreLocation" -framework "CoreTelephony"
  -framework "mPulse"
```

After the fix, we correctly only include `-framework "mPulse"`

```
OTHER_LDFLAGS = $(inherited) -ObjC -l"c++"
  -l"sqlite3" -l"z"
  -framework "CoreData" -framework "CoreLocation" -framework "CoreTelephony"
  -framework "mPulse"
```

When not using `use_frameworks!`, `OTHER_LDFLAGS` should not be changed, i.e. having `-l"mPulse" -l"mPulseDevice" -l"mPulseSim"` and no `-framework`:

```
OTHER_LDFLAGS = $(inherited) -ObjC -l"c++"
  -l"mPulse" -l"mPulseDevice" -l"mPulseSim"
  -l"sqlite3" -l"z"
  -framework "CoreData" -framework "CoreLocation" -framework "CoreTelephony"
```