### PR TITLE
Add JSON file for Carthage binary artifact management

### DIFF
--- a/mPulse.json
+++ b/mPulse.json
@@ -1,0 +1,9 @@
+{
+  "2.3.5":"https://github.com/akamai/mPulse-iOS/raw/2.3.5/MPulse.framework.zip",
+  "2.3.6":"https://github.com/akamai/mPulse-iOS/raw/2.3.6/MPulse.framework.zip",
+  "2.6.0":"https://github.com/akamai/mPulse-iOS/raw/2.6.0/MPulse.framework.zip",
+  "2.6.1":"https://github.com/akamai/mPulse-iOS/raw/2.6.1/MPulse.framework.zip",
+  "2.6.2":"https://github.com/akamai/mPulse-iOS/raw/2.6.2/MPulse.framework.zip",
+  "2.6.3":"https://github.com/akamai/mPulse-iOS/raw/2.6.3/MPulse.framework.zip",
+  "2.6.4":"https://github.com/akamai/mPulse-iOS/raw/2.6.4/MPulse.framework.zip"
+}


### PR DESCRIPTION
As per: https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#binary-only-frameworks
and:
https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#binary-project-specification

We need a JSON file to provide a binary project specification to provide pre-compiled framework zips to Carthage based projects.

This change adds a `mPulse.json` facilitating the above.

A customer then may use the JSON file to reference our project for integration.